### PR TITLE
feat: add support for default API key handling in logging and tracing

### DIFF
--- a/common/api.go
+++ b/common/api.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/codifinary/codexray-node-agent/flags"
 )
 
@@ -10,4 +12,54 @@ func AuthHeaders() map[string]string {
 		res["X-Api-Key"] = apiKey
 	}
 	return res
+}
+
+func AuthHeadersForContainer(containerId string) map[string]string {
+	res := map[string]string{}
+	if containerId != "" && strings.Contains(containerId, "codexray") {
+		if defaultKey := *flags.DefaultApiKey; defaultKey != "" {
+			res["X-Api-Key"] = defaultKey
+			return res
+		}
+	}
+	if apiKey := *flags.ApiKey; apiKey != "" {
+		res["X-Api-Key"] = apiKey
+	}
+	return res
+}
+
+// AuthHeadersForServiceName checks the service name (used by traces, logs, profiling)
+func AuthHeadersForServiceName(serviceName string) map[string]string {
+	res := map[string]string{}
+	if serviceName != "" && strings.Contains(serviceName, "codexray") {
+		if defaultKey := *flags.DefaultApiKey; defaultKey != "" {
+			res["X-Api-Key"] = defaultKey
+			return res
+		}
+	}
+	if apiKey := *flags.ApiKey; apiKey != "" {
+		res["X-Api-Key"] = apiKey
+	}
+	return res
+}
+
+func ApiKeyTypeForContainer(containerId string) string {
+	if containerId != "" && strings.Contains(containerId, "codexray") {
+		if defaultKey := *flags.DefaultApiKey; defaultKey != "" {
+			_ = defaultKey
+			return "DEFAULT"
+		}
+	}
+	return "REGULAR"
+}
+
+// ApiKeyTypeForServiceName checks the service name (used by traces, logs, profiling)
+func ApiKeyTypeForServiceName(serviceName string) string {
+	if serviceName != "" && strings.Contains(serviceName, "codexray") {
+		if defaultKey := *flags.DefaultApiKey; defaultKey != "" {
+			_ = defaultKey
+			return "DEFAULT"
+		}
+	}
+	return "REGULAR"
 }

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -39,6 +39,7 @@ var (
 
 	CollectorEndpoint  = kingpin.Flag("collector-endpoint", "A base endpoint URL for metrics, traces, logs, and profiles").Envar("COLLECTOR_ENDPOINT").URL()
 	ApiKey             = kingpin.Flag("api-key", "Codexray API key").Envar("API_KEY").String()
+	DefaultApiKey      = kingpin.Flag("default-api-key", "Default Codexray API key for codexray containers").Envar("DEFAULT_API_KEY").String()
 	MetricsEndpoint    = kingpin.Flag("metrics-endpoint", "The URL of the endpoint to send metrics to").Envar("METRICS_ENDPOINT").URL()
 	TracesEndpoint     = kingpin.Flag("traces-endpoint", "The URL of the endpoint to send traces to").Envar("TRACES_ENDPOINT").URL()
 	TracesSampling     = kingpin.Flag("traces-sampling", "Trace sampling rate (0.0 to 1.0)").Default("1.0").Envar("TRACES_SAMPLING").Float64()

--- a/logs/otel.go
+++ b/logs/otel.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"crypto/tls"
+	"strings"
 	"time"
 
 	otel "github.com/agoda-com/opentelemetry-logs-go"
@@ -19,7 +20,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var otelLogger otelLogs.Logger
+var (
+	otelLogger        otelLogs.Logger
+	otelLoggerDefault otelLogs.Logger
+)
 
 func Init(machineId, hostname, version string) {
 	endpointUrl := *flags.LogsEndpoint
@@ -28,14 +32,22 @@ func Init(machineId, hostname, version string) {
 		return
 	}
 	klog.Infoln("OpenTelemetry logs collector endpoint:", endpointUrl.String())
-	path := endpointUrl.Path
-	if path == "" {
-		path = "/"
+	urlPath := endpointUrl.Path
+	if urlPath == "" {
+		urlPath = "/"
 	}
 
+	resourceAttrs := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("codexray-node-agent"),
+		semconv.HostName(hostname),
+		semconv.HostID(machineId),
+	)
+
+	// Regular logger provider (uses API_KEY)
 	opts := []otlplogshttp.Option{
 		otlplogshttp.WithEndpoint(endpointUrl.Host),
-		otlplogshttp.WithURLPath(path),
+		otlplogshttp.WithURLPath(urlPath),
 		otlplogshttp.WithHeaders(common.AuthHeaders()),
 		otlplogshttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}),
 	}
@@ -47,23 +59,47 @@ func Init(machineId, hostname, version string) {
 
 	loggerProvider := sdk.NewLoggerProvider(
 		sdk.WithBatcher(exporter),
-		sdk.WithResource(
-			resource.NewWithAttributes(
-				semconv.SchemaURL,
-				semconv.ServiceName("codexray-node-agent"),
-				semconv.HostName(hostname),
-				semconv.HostID(machineId),
-			),
-		),
+		sdk.WithResource(resourceAttrs),
 	)
 	otel.SetLoggerProvider(loggerProvider)
 	otelLogger = loggerProvider.Logger("codexray-node-agent", otelLogs.WithInstrumentationVersion(version))
+
+	// Default logger provider (uses DEFAULT_API_KEY for codexray containers)
+	defaultOpts := []otlplogshttp.Option{
+		otlplogshttp.WithEndpoint(endpointUrl.Host),
+		otlplogshttp.WithURLPath(urlPath),
+		otlplogshttp.WithHeaders(common.AuthHeadersForContainer("codexray")),
+		otlplogshttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}),
+	}
+	if endpointUrl.Scheme != "https" {
+		defaultOpts = append(defaultOpts, otlplogshttp.WithInsecure())
+	}
+	defaultClient := otlplogshttp.NewClient(defaultOpts...)
+	defaultExporter, _ := otlplogs.NewExporter(context.Background(), otlplogs.WithClient(defaultClient))
+
+	defaultLoggerProvider := sdk.NewLoggerProvider(
+		sdk.WithBatcher(defaultExporter),
+		sdk.WithResource(resourceAttrs),
+	)
+	otelLoggerDefault = defaultLoggerProvider.Logger("codexray-node-agent", otelLogs.WithInstrumentationVersion(version))
 }
 
 func OtelLogEmitter(containerId string) logparser.OnMsgCallbackF {
 	if otelLogger == nil {
 		return nil
 	}
+
+	// Choose the appropriate logger based on service name
+	serviceName := common.ContainerIdToOtelServiceName(containerId)
+	logger := otelLogger
+	apiKeyType := "REGULAR"
+	if strings.Contains(serviceName, "codexray") && otelLoggerDefault != nil {
+		logger = otelLoggerDefault
+		apiKeyType = "DEFAULT"
+	}
+	logsApiKey := common.AuthHeadersForServiceName(serviceName)["X-Api-Key"]
+	klog.Infof("[type=logs] emitter created for container_id=%s service_name=%s api_key_type=%s X-Api-Key=%s", containerId, serviceName, apiKeyType, logsApiKey)
+
 	return func(ts time.Time, level logparser.Level, patternHash string, msg string) {
 		severityText := level.String()
 		severityNumber := otelLogs.UNSPECIFIED
@@ -80,7 +116,7 @@ func OtelLogEmitter(containerId string) logparser.OnMsgCallbackF {
 			severityNumber = otelLogs.DEBUG
 		}
 
-		otelLogger.Emit(
+		logger.Emit(
 			otelLogs.NewLogRecord(otelLogs.LogRecordConfig{
 				ObservedTimestamp: ts,
 				SeverityText:      &severityText,

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -153,12 +153,16 @@ func collect() {
 func upload(b *pprof.ProfileBuilder) error {
 	u := *endpointUrl
 	q := u.Query()
+	var serviceName string
+	var containerId string
 	for _, l := range b.Labels {
 		switch l.Name {
 		case "service_name":
 			l.Name = "service.name"
+			serviceName = l.Value
 		case "__container_id__":
 			l.Name = "container.id"
+			containerId = l.Value
 		default:
 			continue
 		}
@@ -181,9 +185,13 @@ func upload(b *pprof.ProfileBuilder) error {
 	if err != nil {
 		return err
 	}
-	for k, v := range common.AuthHeaders() {
+	authHeaders := common.AuthHeadersForServiceName(serviceName)
+	for k, v := range authHeaders {
 		req.Header.Set(k, v)
 	}
+	apiKeyType := common.ApiKeyTypeForServiceName(serviceName)
+	apiKeyValue := authHeaders["X-Api-Key"]
+	klog.Infof("[type=profiles] sending to URL=%s container_id=%s service_name=%s api_key_type=%s X-Api-Key=%s", u.String(), containerId, serviceName, apiKeyType, apiKeyValue)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err

--- a/prom/remote_writer.go
+++ b/prom/remote_writer.go
@@ -140,13 +140,27 @@ func (a *Agent) send(fPath string) error {
 	if err != nil {
 		return err
 	}
-	for k, v := range common.AuthHeaders() {
+
+	// Determine API key based on spool file name
+	var authHeaders map[string]string
+	var apiKeyType string
+	baseName := path.Base(fPath)
+	if strings.Contains(baseName, "-default") {
+		authHeaders = common.AuthHeadersForContainer("codexray")
+		apiKeyType = "DEFAULT"
+	} else {
+		authHeaders = common.AuthHeaders()
+		apiKeyType = "REGULAR"
+	}
+	for k, v := range authHeaders {
 		req.Header.Set(k, v)
 	}
 	req.Header.Set("User-Agent", "codexray-node-agent")
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("Content-Encoding", "snappy")
 	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+	apiKeyValue := authHeaders["X-Api-Key"]
+	klog.Infof("[type=metrics] sending to URL=%s spool_file=%s api_key_type=%s X-Api-Key=%s", a.url.String(), baseName, apiKeyType, apiKeyValue)
 	t := time.Now()
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
@@ -172,21 +186,66 @@ func (a *Agent) scrape() error {
 		mfsByName[mf.GetName()] = mf
 	}
 	wr := buildWriteRequest(mfs, timestamp, a.labels)
-	decompressed, err := wr.Marshal()
-	if err != nil {
-		return err
+
+	// Partition timeseries into regular and codexray (default) groups
+	var regularTS []prompb.TimeSeries
+	var defaultTS []prompb.TimeSeries
+	for _, ts := range wr.Timeseries {
+		if timeseriesHasCodexrayContainer(ts) {
+			defaultTS = append(defaultTS, ts)
+		} else {
+			regularTS = append(regularTS, ts)
+		}
 	}
 
-	compressed := snappy.Encode(nil, decompressed)
-	err = a.writeToSpool(timestamp, compressed)
-	return err
+	// Write regular timeseries spool file
+	if len(regularTS) > 0 {
+		regularWr := &prompb.WriteRequest{Timeseries: regularTS, Metadata: wr.Metadata}
+		decompressed, err := regularWr.Marshal()
+		if err != nil {
+			return err
+		}
+		compressed := snappy.Encode(nil, decompressed)
+		if err := a.writeToSpoolWithSuffix(timestamp, compressed, ""); err != nil {
+			return err
+		}
+	}
+
+	// Write codexray (default API key) timeseries spool file
+	if len(defaultTS) > 0 {
+		defaultWr := &prompb.WriteRequest{Timeseries: defaultTS, Metadata: wr.Metadata}
+		decompressed, err := defaultWr.Marshal()
+		if err != nil {
+			return err
+		}
+		compressed := snappy.Encode(nil, decompressed)
+		if err := a.writeToSpoolWithSuffix(timestamp, compressed, "-default"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// timeseriesHasCodexrayContainer checks if a timeseries has a container_id label containing "codexray".
+func timeseriesHasCodexrayContainer(ts prompb.TimeSeries) bool {
+	for _, l := range ts.Labels {
+		if l.Name == "container_id" && strings.Contains(l.Value, "codexray") {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *Agent) writeToSpool(timestamp int64, payload []byte) error {
+	return a.writeToSpoolWithSuffix(timestamp, payload, "")
+}
+
+func (a *Agent) writeToSpoolWithSuffix(timestamp int64, payload []byte, suffix string) error {
 	if err := a.truncateSpoolIfNeeded(); err != nil {
 		return err
 	}
-	fileName := fmt.Sprintf("spool-%d.done", timestamp)
+	fileName := fmt.Sprintf("spool-%d%s.done", timestamp, suffix)
 	f, err := os.CreateTemp(a.spoolDir, fileName)
 	if err != nil {
 		return err

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/codifinary/codexray-node-agent/common"
@@ -27,6 +28,7 @@ const (
 
 var (
 	batcher             sdktrace.TracerProviderOption
+	batcherDefault      sdktrace.TracerProviderOption
 	commonResourceAttrs []attribute.KeyValue
 	agentVersion        string
 	initialized         bool
@@ -49,13 +51,15 @@ func Init(machineId, hostname, version string) {
 		klog.Infof("trace sampling rate set to %f", samplingRate)
 	}
 	klog.Infoln("OpenTelemetry traces collector endpoint:", endpointUrl.String())
-	path := endpointUrl.Path
-	if path == "" {
-		path = "/"
+	urlPath := endpointUrl.Path
+	if urlPath == "" {
+		urlPath = "/"
 	}
+
+	// Regular exporter (uses API_KEY)
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(endpointUrl.Host),
-		otlptracehttp.WithURLPath(path),
+		otlptracehttp.WithURLPath(urlPath),
 		otlptracehttp.WithHeaders(common.AuthHeaders()),
 		otlptracehttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}),
 	}
@@ -67,8 +71,25 @@ func Init(machineId, hostname, version string) {
 	if err != nil {
 		klog.Exitln(err)
 	}
-
 	batcher = sdktrace.WithBatcher(exporter)
+
+	// Default exporter (uses DEFAULT_API_KEY for codexray containers)
+	defaultOpts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(endpointUrl.Host),
+		otlptracehttp.WithURLPath(urlPath),
+		otlptracehttp.WithHeaders(common.AuthHeadersForContainer("codexray")),
+		otlptracehttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}),
+	}
+	if endpointUrl.Scheme != "https" {
+		defaultOpts = append(defaultOpts, otlptracehttp.WithInsecure())
+	}
+	defaultClient := otlptracehttp.NewClient(defaultOpts...)
+	defaultExporter, err := otlptrace.New(context.Background(), defaultClient)
+	if err != nil {
+		klog.Exitln(err)
+	}
+	batcherDefault = sdktrace.WithBatcher(defaultExporter)
+
 	commonResourceAttrs = []attribute.KeyValue{semconv.HostName(hostname), semconv.HostID(machineId)}
 	agentVersion = version
 	initialized = true
@@ -93,8 +114,20 @@ func GetContainerTracer(containerId string) *Tracer {
 	if !initialized {
 		return &Tracer{otel: nil}
 	}
+
+	// Choose the appropriate batcher based on service name
+	serviceName := common.ContainerIdToOtelServiceName(containerId)
+	selectedBatcher := batcher
+	apiKeyType := "REGULAR"
+	if strings.Contains(serviceName, "codexray") && batcherDefault != nil {
+		selectedBatcher = batcherDefault
+		apiKeyType = "DEFAULT"
+	}
+	tracesApiKey := common.AuthHeadersForServiceName(serviceName)["X-Api-Key"]
+	klog.Infof("[type=traces] tracer created for container_id=%s service_name=%s api_key_type=%s X-Api-Key=%s", containerId, serviceName, apiKeyType, tracesApiKey)
+
 	provider := sdktrace.NewTracerProvider(
-		batcher,
+		selectedBatcher,
 		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
 			append(


### PR DESCRIPTION
- Introduced `DefaultApiKey` flag for codexray containers.
- Enhanced `AuthHeadersForContainer` and `AuthHeadersForServiceName` functions to utilize the default API key.
- Updated logging and tracing initialization to select appropriate API key based on service name.
- Modified metrics and profiling uploads to differentiate between regular and default API key usage.