### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Codifinary/global-codeowners


### PR DESCRIPTION
Adds .github/CODEOWNERS assigning @Codifinary/global-codeowners as code owners for all paths.